### PR TITLE
Fixing tapestry-model-hibernate version

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -277,7 +277,7 @@
 		<dependency>
 			<groupId>org.tynamo</groupId>
 			<artifactId>tapestry-model-hibernate</artifactId>
-			<version>${D}{tynamo-version}</version>
+			<version>0.6.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Was pointing to 0.6.0-SNAPSHO (Tynamo version)
